### PR TITLE
17 change set handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stack-Manager
+# stackmanager
 
 [![PyPI version](https://badge.fury.io/py/stackmanager.svg)](https://badge.fury.io/py/stackmanager)
 
@@ -114,16 +114,27 @@ Usage: stackmanager deploy [OPTIONS]
   Create or update a CloudFormation stack using ChangeSets.
 
 Options:
-  -p, --profile TEXT       AWS Profile, will use default or environment variables if not specified
-  -c, --config TEXT       YAML Configuration file  [required]
-  -e, --environment TEXT  Environment to deploy  [required]
-  -r, --region TEXT       AWS Region to deploy  [required]
-  -t, --template TEXT     Override template
-  --parameter TEXT...     Override a parameter, can be specified multiple times
-  --change-set-name TEXT  Custom ChangeSet name
-  --auto-apply            Automatically apply created ChangeSet
-  --help                  Show this message and exit.
+  -p, --profile TEXT              AWS Profile, will use default or environment
+                                  variables if not specified
+
+  -c, --config TEXT               YAML Configuration file  [required]
+  -e, --environment TEXT          Environment to deploy  [required]
+  -r, --region TEXT               AWS Region to deploy  [required]
+  -t, --template TEXT             Override template
+  --parameter TEXT...             Override a parameter, can be specified
+                                  multiple times
+  --change-set-name TEXT          Custom ChangeSet name
+  --existing-changes [ALLOW|FAILED_ONLY|DISALLOW]
+                                  Whether deployment is allowed when there are
+                                  existing ChangeSets
+  --auto-apply                    Automatically apply created ChangeSet
+  --help                          Show this message and exit.
 ```
+
+_(since 0.7.0)_ Existing ChangeSets, if any, will be listed for the stack and depending upon the `--existing-changes`
+value (which defaults to `ALLOW`) this may prevent the deployment. If set to `FAILED_ONLY` then failed ChangeSets
+will not prevent a new change from being created, but if set to `DISALLOW` any existing ChangeSets will prevent new
+changes.
 
 ### apply
 
@@ -131,16 +142,24 @@ Options:
 Usage: stackmanager apply [OPTIONS]
 
   Apply a CloudFormation ChangeSet to create or update a CloudFormation
-  stack.
+  stack. If using --change-set-name then --config --environment are --region
+  are required. If using --change-set-id no other values are required
+  (although --profile and --region may be needed).
 
 Options:
-  -p, --profile TEXT       AWS Profile, will use default or environment variables if not specified
-  -c, --config TEXT       YAML Configuration file  [required]
-  -e, --environment TEXT  Environment to deploy  [required]
-  -r, --region TEXT       AWS Region to deploy  [required]
-  --change-set-name TEXT  ChangeSet to apply  [required]
+  -p, --profile TEXT      AWS Profile, will use default or environment
+                          variables if not specified
+
+  -c, --config TEXT       YAML Configuration file
+  -e, --environment TEXT  Environment to deploy
+  -r, --region TEXT       AWS Region to deploy
+  --change-set-name TEXT  Name of ChangeSet to apply
+  --change-set-id TEXT    Identifier of ChangeSet to apply
   --help                  Show this message and exit.
 ```
+
+_(since 0.7.0)_ Using `--change-set-id` allows you to apply a ChangeSet without loading the configuration.
+This can be useful in a CI/CD pipeline as this may avoid the need to checkout the repository for applying a change.
 
 ### delete
 
@@ -200,10 +219,10 @@ Stackmanager will automatically detect when it is running in an Azure DevOps pip
 It will print `##vso` strings under the following circumstances:
 
 * `deploy` has created a ChangeSet and it has not been auto-applied: \
-  This sets a variable named `change_set_name` containing the `change_set_name` that can be used with the `apply` 
-  command in a later step/job/stage.\
-  The name of the variable can be overridden by setting the `CHANGE_SET_VARIABLE` environment variable.
-* `deploy` has created a ChangeSet but it contains no changes: \
+  Sets two variables for the ChangeSet name and identifier. These default to `change_set_name` and `change_set_id`
+  _(since 0.7.0)_ but the name of these variables can be changed with the `CHANGE_SET_NAME_VARIABLE` and 
+  `CHANGE_SET_ID_VARIABLE` environment variables. These values can be used with the `apply` command in a later stage.
+* `deploy` has created a ChangeSet but it contains no changes:\
    This logs a warning (`##vso[task.logissue]`) and sets the status to `SucceededWithIssues` (`##vso[task.complete]`)
    allowing following steps/jobs/stages to be skipped by checking for the `SucceededStatus` in a condition.
 * `deploy` or `apply` fails when applying a ChangeSet: \

--- a/stackmanager/cli.py
+++ b/stackmanager/cli.py
@@ -26,14 +26,17 @@ def cli(ctx):
 @click.option('-t', '--template', help='Override template')
 @click.option('--parameter', nargs=2, multiple=True, help='Override a parameter, can be specified multiple times')
 @click.option('--change-set-name', help='Custom ChangeSet name')
+@click.option('--existing-changes', type=click.Choice(['ALLOW', 'FAILED_ONLY', 'DISALLOW'], case_sensitive=False),
+              default='ALLOW', help='Whether deployment is allowed when there are existing ChangeSets')
 @click.option('--auto-apply', is_flag=True, help='Automatically apply created ChangeSet')
-def deploy(ctx, profile, config, environment, region, template, parameter, change_set_name, auto_apply):
+def deploy(ctx, profile, config, environment, region, template, parameter, change_set_name, existing_changes,
+           auto_apply):
     """
     Create or update a CloudFormation stack using ChangeSets.
     """
     try:
         cfg = load_config(config, environment, region, Template=template, Parameters=parameter,
-                          ChangeSetName=change_set_name, AutoApply=auto_apply)
+                          ChangeSetName=change_set_name, ExistingChanges=existing_changes, AutoApply=auto_apply)
         runner = create_runner(profile, cfg)
         runner.deploy()
     except (ValidationError, StackError) as e:
@@ -47,13 +50,13 @@ def deploy(ctx, profile, config, environment, region, template, parameter, chang
 @click.option('-c', '--config', help='YAML Configuration file')
 @click.option('-e', '--environment', help='Environment to deploy')
 @click.option('-r', '--region', help='AWS Region to deploy')
-@click.option('--change-set-name', help='ChangeSet to apply')
-@click.option('--change-set-id', help='ChangeSet to apply')
+@click.option('--change-set-name', help='Name of ChangeSet to apply')
+@click.option('--change-set-id', help='Identifier of ChangeSet to apply')
 def apply(ctx, profile, config, environment, region, change_set_name, change_set_id):
     """
     Apply a CloudFormation ChangeSet to create or update a CloudFormation stack.
-    If using --change-set-name then --config and --environment are also required as well as --region.
-    If using --change-set-id then only --region is required.
+    If using --change-set-name then --config --environment are --region are required.
+    If using --change-set-id no other values are required (although --profile and --region may be needed).
     """
     if not change_set_name and not change_set_id:
         raise click.UsageError("Option '--change-set-name' or '--change-set-id' required.")

--- a/stackmanager/cli.py
+++ b/stackmanager/cli.py
@@ -32,8 +32,9 @@ def deploy(ctx, profile, config, environment, region, template, parameter, chang
     Create or update a CloudFormation stack using ChangeSets.
     """
     try:
-        cfg = load_config(config, environment, region, template, parameter)
-        runner = create_runner(profile, cfg, change_set_name, auto_apply)
+        cfg = load_config(config, environment, region, Template=template, Parameters=parameter,
+                          ChangeSetName=change_set_name, AutoApply=auto_apply)
+        runner = create_runner(profile, cfg)
         runner.deploy()
     except (ValidationError, StackError) as e:
         error(f'\nError: {e}')
@@ -52,8 +53,8 @@ def apply(ctx, profile, config, environment, region, change_set_name):
     Apply a CloudFormation ChangeSet to create or update a CloudFormation stack.
     """
     try:
-        cfg = load_config(config, environment, region, None, None, False)
-        runner = create_runner(profile, cfg, change_set_name, False)
+        cfg = load_config(config, environment, region, False, ChangeSetName=change_set_name)
+        runner = create_runner(profile, cfg)
         runner.execute_change_set()
     except (ValidationError, StackError) as e:
         error(f'\nError: {e}')
@@ -72,8 +73,8 @@ def delete(ctx, profile, config, environment, region, retain_resources):
     Delete a CloudFormation stack.
     """
     try:
-        cfg = load_config(config, environment, region, None, None, False)
-        runner = create_runner(profile, cfg, None, False)
+        cfg = load_config(config, environment, region, False)
+        runner = create_runner(profile, cfg)
         runner.delete(retain_resources)
     except (ValidationError, StackError) as e:
         error(f'\nError: {e}')

--- a/stackmanager/cli.py
+++ b/stackmanager/cli.py
@@ -4,7 +4,7 @@ import stackmanager.packager
 from stackmanager.exceptions import PackagingError, StackError, TransferError, ValidationError
 from stackmanager.loader import load_config
 from stackmanager.messages import error
-from stackmanager.runner import create_runner
+from stackmanager.runner import create_runner, create_changeset_runner
 from stackmanager.uploader import create_uploader
 
 
@@ -44,18 +44,33 @@ def deploy(ctx, profile, config, environment, region, template, parameter, chang
 @cli.command()
 @click.pass_context
 @click.option('-p', '--profile', help='AWS Profile, will use default or environment variables if not specified')
-@click.option('-c', '--config', required=True, help='YAML Configuration file')
-@click.option('-e', '--environment', required=True, help='Environment to deploy')
-@click.option('-r', '--region', required=True, help='AWS Region to deploy')
-@click.option('--change-set-name', required=True, help='ChangeSet to apply')
-def apply(ctx, profile, config, environment, region, change_set_name):
+@click.option('-c', '--config', help='YAML Configuration file')
+@click.option('-e', '--environment', help='Environment to deploy')
+@click.option('-r', '--region', help='AWS Region to deploy')
+@click.option('--change-set-name', help='ChangeSet to apply')
+@click.option('--change-set-id', help='ChangeSet to apply')
+def apply(ctx, profile, config, environment, region, change_set_name, change_set_id):
     """
     Apply a CloudFormation ChangeSet to create or update a CloudFormation stack.
+    If using --change-set-name then --config and --environment are also required as well as --region.
+    If using --change-set-id then only --region is required.
     """
+    if not change_set_name and not change_set_id:
+        raise click.UsageError("Option '--change-set-name' or '--change-set-id' required.")
+
     try:
-        cfg = load_config(config, environment, region, False, ChangeSetName=change_set_name)
-        runner = create_runner(profile, cfg)
-        runner.execute_change_set()
+        if change_set_id:
+            runner = create_changeset_runner(profile, region, change_set_id)
+            runner.execute_change_set()
+        else:
+            if not config:
+                raise click.UsageError("Missing option '-c' / '--config'.")
+            if not environment:
+                raise click.UsageError("Missing option '-e' / '--environment'.")
+
+            cfg = load_config(config, environment, region, False, ChangeSetName=change_set_name)
+            runner = create_runner(profile, cfg)
+            runner.execute_change_set()
     except (ValidationError, StackError) as e:
         error(f'\nError: {e}')
         exit(1)

--- a/stackmanager/config.py
+++ b/stackmanager/config.py
@@ -12,6 +12,7 @@ TAGS = 'Tags'
 CAPABILITIES = 'Capabilities'
 CHANGE_SET_NAME = 'ChangeSetName'
 CHANGE_SET_ID = 'ChangeSetId'
+EXISTING_CHANGES = 'ExistingChanges'
 AUTO_APPLY = 'AutoApply'
 
 
@@ -174,6 +175,10 @@ class Config:
     @property
     def change_set_id(self):
         return self.__get_value(CHANGE_SET_ID, False)
+
+    @property
+    def existing_changes(self):
+        return self.__get_value(EXISTING_CHANGES, True)
 
     @property
     def auto_apply(self):

--- a/stackmanager/config.py
+++ b/stackmanager/config.py
@@ -3,6 +3,18 @@ from stackmanager.exceptions import ValidationError
 from jinja2 import Template
 
 
+ENVIRONMENT = 'Environment'
+REGION = 'Region'
+STACK_NAME = 'StackName'
+PARAMETERS = 'Parameters'
+TEMPLATE = 'Template'
+TAGS = 'Tags'
+CAPABILITIES = 'Capabilities'
+CHANGE_SET_NAME = 'ChangeSetName'
+CHANGE_SET_ID = 'ChangeSetId'
+AUTO_APPLY = 'AutoApply'
+
+
 class Config:
     """
     Encapsulates Configuration for one of the following:
@@ -21,8 +33,8 @@ class Config:
         """
         self.parent = None
         self.config = config
-        self.environment = config.get('Environment')
-        self.region = config.get('Region')
+        self.environment = config.get(ENVIRONMENT)
+        self.region = config.get(REGION)
 
         if not self.environment:
             raise ValidationError('Environment is required')
@@ -118,7 +130,7 @@ class Config:
         Get Stack Name required property
         :return: Stack name, evaluated as a Jinja2 template
         """
-        template = Template(self.__get_value('StackName', True))
+        template = Template(self.__get_value(STACK_NAME, True))
         return template.render(Environment=self.environment, Region=self.region)
 
     @property
@@ -127,7 +139,7 @@ class Config:
         Get Template required property
         :return: Template path or URL
         """
-        return self.__get_value('Template', True)
+        return self.__get_value(TEMPLATE, True)
 
     @property
     def parameters(self):
@@ -136,7 +148,7 @@ class Config:
         and substituting any templated values
         :return: Parameters dictionary
         """
-        return self.__template_all(self.__get_dict('Parameters'))
+        return self.__template_all(self.__get_dict(PARAMETERS))
 
     @property
     def tags(self):
@@ -145,7 +157,7 @@ class Config:
         and substituting any templated values
         :return: Tags dictionary
         """
-        return self.__template_all(self.__get_dict('Tags'))
+        return self.__template_all(self.__get_dict(TAGS))
 
     @property
     def capabilities(self):
@@ -153,7 +165,19 @@ class Config:
         Get list of capabilities
         :return: Capabilities
         """
-        return self.__get_list('Capabilities')
+        return self.__get_list(CAPABILITIES)
+
+    @property
+    def change_set_name(self):
+        return self.__get_value(CHANGE_SET_NAME, False)
+
+    @property
+    def change_set_id(self):
+        return self.__get_value(CHANGE_SET_ID, False)
+
+    @property
+    def auto_apply(self):
+        return self.__get_value(AUTO_APPLY, False) or False
 
     def validate(self, check_template=True):
         """

--- a/stackmanager/loader.py
+++ b/stackmanager/loader.py
@@ -1,22 +1,21 @@
-from stackmanager.exceptions import ValidationError
-from stackmanager.config import Config
+from .exceptions import ValidationError
+from .config import Config, ENVIRONMENT, REGION, TEMPLATE, PARAMETERS, CHANGE_SET_NAME, CHANGE_SET_ID, AUTO_APPLY
 import yaml
 
 
-def load_config(config_file, environment, region, template, parameters, check_template=True):
+def load_config(config_file, environment, region, check_template=True, **kwargs):
     """
     Build hierarchy of configurations by loading multi-document config file.
     There must be a matching config for the environment name and region.
     :param str config_file: Path to config file
     :param str environment: Environment being updated
     :param str region: Region for the Stack
-    :param str template: Override value for Template from command line
-    :param list parameters: Override values for Parameters from the command line
     :param bool check_template: Check Template exists when validating config
+    :param dict kwargs: Other arguments to be added to arg config
     :return: Top of Config hierarchy
     :raises validationException: If config file not found, matching environment not found in config or config is invalid
     """
-    arg_config = create_arg_config(environment, region, template, parameters)
+    arg_config = create_arg_config(environment, region, kwargs)
 
     try:
         with open(config_file) as c:
@@ -43,22 +42,28 @@ def load_config(config_file, environment, region, template, parameters, check_te
         raise ValidationError(f'Config file {config_file} not found')
 
 
-def create_arg_config(environment, region, template, parameters):
+def create_arg_config(environment, region, kwargs):
     """
     Create a Configuration from the command line arguments, used as top of hierarchy to
     optionally override template and parameters.
     :param str environment: Environment
     :param str region: Region to deploy
-    :param str template: Override value for Template from command line
-    :param list parameters: Override values for Parameters from the command line
+    :param dict kwargs: Other arguments to be added to arg config
     :return: Argument Config
     """
     raw_config = {
-        'Environment': environment,
-        'Region': region
+        ENVIRONMENT: environment,
+        REGION: region
     }
-    if template:
-        raw_config['Template'] = template
-    if parameters:
-        raw_config['Parameters'] = dict(parameters)
+    if TEMPLATE in kwargs:
+        raw_config[TEMPLATE] = kwargs[TEMPLATE]
+    if PARAMETERS in kwargs:
+        raw_config[PARAMETERS] = dict(kwargs[PARAMETERS])
+    if CHANGE_SET_NAME in kwargs:
+        raw_config[CHANGE_SET_NAME] = kwargs[CHANGE_SET_NAME]
+    if CHANGE_SET_ID in kwargs:
+        raw_config[CHANGE_SET_ID] = kwargs[CHANGE_SET_ID]
+    if AUTO_APPLY in kwargs:
+        raw_config[AUTO_APPLY] = kwargs[AUTO_APPLY]
+
     return Config(raw_config)

--- a/stackmanager/loader.py
+++ b/stackmanager/loader.py
@@ -1,5 +1,5 @@
 from .exceptions import ValidationError
-from .config import Config, ENVIRONMENT, REGION, TEMPLATE, PARAMETERS, CHANGE_SET_NAME, CHANGE_SET_ID, AUTO_APPLY
+from .config import Config, ENVIRONMENT, REGION, TEMPLATE, PARAMETERS, CHANGE_SET_NAME, CHANGE_SET_ID, EXISTING_CHANGES, AUTO_APPLY
 import yaml
 
 
@@ -63,6 +63,8 @@ def create_arg_config(environment, region, kwargs):
         raw_config[CHANGE_SET_NAME] = kwargs[CHANGE_SET_NAME]
     if CHANGE_SET_ID in kwargs:
         raw_config[CHANGE_SET_ID] = kwargs[CHANGE_SET_ID]
+    if EXISTING_CHANGES in kwargs:
+        raw_config[EXISTING_CHANGES] = kwargs[EXISTING_CHANGES]
     if AUTO_APPLY in kwargs:
         raw_config[AUTO_APPLY] = kwargs[AUTO_APPLY]
 

--- a/stackmanager/runner.py
+++ b/stackmanager/runner.py
@@ -14,18 +14,16 @@ class Runner:
     Encapsulates calls to CloudFormation client to create, update and delete stacks
     """
 
-    def __init__(self, client, config, change_set_name, auto_apply):
+    def __init__(self, client, config):
         """
         Initialize new instance
         :param client: CloudFormation client
         :param Config config: Parsed configuration
-        :param str change_set_name: ChangeSet name to use, if not set a guid will be generated
-        :param bool auto_apply: Whether to automatically apply changes
         """
         self.client = client
         self.config = config
+        change_set_name = config.change_set_name
         self.change_set_name = change_set_name if change_set_name else 'c'+str(uuid.uuid4()).replace('-', '')
-        self.auto_apply = auto_apply
         self.stack = self.load_stack()
 
     def load_stack(self):
@@ -63,7 +61,7 @@ class Runner:
         try:
             self.client.create_change_set(**self.build_change_set_args())
             if self.wait_for_change_set():
-                if self.auto_apply:
+                if self.config.auto_apply:
                     self.execute_change_set()
                 else:
                     self.pending_change_set()
@@ -282,19 +280,17 @@ class AzureDevOpsRunner(Runner):
               f'({self.config.environment}/{self.config.region}) - ChangeSet {self.change_set_name} failed')
 
 
-def create_runner(profile, config, change_set_name, auto_apply):
+def create_runner(profile, config):
     """
     Factory method for runner, responsible for creating boto3 client and picking appropriate Runner implementation.
     :param str profile: AWS Profile from command line
     :param Config config: Parsed Configuration
-    :param str change_set_name: Name of ChangeSet to use
-    :param bool auto_apply: Whether to automatically apply changes
     :return: Runner instance
     """
     session = boto3.Session(profile_name=profile, region_name=config.region)
     client = session.client('cloudformation')
     azure_devops = 'SYSTEM_TEAMPROJECTID' in os.environ
     if azure_devops:
-        return AzureDevOpsRunner(client, config, change_set_name, auto_apply)
+        return AzureDevOpsRunner(client, config)
     else:
-        return Runner(client, config, change_set_name, auto_apply)
+        return Runner(client, config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,6 +106,41 @@ def test_tags_dev(dev_config):
     }
 
 
+def test_change_set_name():
+    config = Config({
+        'Environment': 'dev',
+        'Region': 'us-east-1',
+        'ChangeSetName': 'TestChangeSet'
+    })
+    assert config.change_set_name == 'TestChangeSet'
+
+
+def test_change_set_id():
+    config = Config({
+        'Environment': 'dev',
+        'Region': 'us-east-1',
+        'ChangeSetId': 'abc123'
+    })
+    assert config.change_set_id == 'abc123'
+
+
+def test_auto_apply():
+    config = Config({
+        'Environment': 'dev',
+        'Region': 'us-east-1',
+        'AutoApply': True
+    })
+    assert config.auto_apply is True
+
+
+def test_auto_apply_default():
+    config = Config({
+        'Environment': 'dev',
+        'Region': 'us-east-1'
+    })
+    assert config.auto_apply is False
+
+
 def test_validate_config_with_template_file():
     config = Config({
         'Environment': 'dev',

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -9,7 +9,7 @@ def config_file(filename='config.yaml'):
 
 
 def test_loader_dev():
-    config = load_config(config_file(), 'dev', 'us-east-1', None, None, False)
+    config = load_config(config_file(), 'dev', 'us-east-1', False)
 
     assert config.environment == 'dev'
     assert config.region == 'us-east-1'
@@ -28,7 +28,7 @@ def test_loader_dev():
 
 
 def test_loader_prod():
-    config = load_config(config_file(), 'prod', 'us-east-2', None, None, False)
+    config = load_config(config_file(), 'prod', 'us-east-2', False)
 
     assert config.environment == 'prod'
     assert config.region == 'us-east-2'
@@ -52,7 +52,8 @@ def test_loader_dev_overrides():
         ('Domain', 'notdev.example.com'),
         ('Extra', 'OverrideDefault')
     ]
-    config = load_config(config_file(), 'dev', 'us-east-1', 'integration/config.yaml', override_parameters, False)
+    config = load_config(config_file(), 'dev', 'us-east-1', False, Template='integration/config.yaml',
+                         Parameters=override_parameters, ChangeSetName='TestChangeSet', AutoApply=True)
 
     assert config.environment == 'dev'
     assert config.region == 'us-east-1'
@@ -64,13 +65,15 @@ def test_loader_dev_overrides():
         'KeyId': 'guid1',
         'Extra': 'OverrideDefault'
     }
+    assert config.change_set_name == 'TestChangeSet'
+    assert config.auto_apply is True
 
 
 def test_loader_missing_environment():
     with pytest.raises(ValidationError, match='Environment test for us-east-1 not found in .*'):
-        load_config(config_file(), 'test', 'us-east-1', None, None)
+        load_config(config_file(), 'test', 'us-east-1')
 
 
 def test_loader_missing_region():
     with pytest.raises(ValidationError, match='Environment dev for us-west-1 not found in .*'):
-        load_config(config_file(), 'dev', 'us-west-1', None, None)
+        load_config(config_file(), 'dev', 'us-west-1')


### PR DESCRIPTION
Moves more values into the Config.
ChangeSets can now be applied without reading config using their id.
Existing ChangeSets will be listed when doing a deploy, and depending upon the `--existing-changes` value this may prevent deployment.