### PR TITLE
Closes #13 - Print outputs and add get-output command

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Stackmanager has the following commands:
 * [`reject`](#reject) - Reject a previously created ChangeSet
 * [`delete`](#delete) - Delete an existing CloudFormation stack
 * [`status`](#status) - Print current status of Stack
+* [`get-output`](#get-output) - Get Stack Output value
 * [`upload`](#upload) - Uploads a local file to S3. Utility method to prevent the need to use the AWS CLI or other tools.
 * [`build-lambda`](#build-lambda) - Build a Lambda zip file using aws-lambda-builders.
 
@@ -134,6 +135,7 @@ Commands:
   build-lambda  Build a Lambda function zip file.
   delete        Delete a CloudFormation stack.
   deploy        Create or update a CloudFormation stack using ChangeSets.
+  get-output    Returns matching Output value if it exists.
   reject        Reject a CloudFormation ChangeSet, deleting the stack if in REVIEW_IN_PROGRESS status and has no other ChangeSets.
   status        Print current status of Stack.
   upload        Uploads a File to S3.
@@ -237,6 +239,35 @@ Options:
   -r, --region TEXT        AWS Region to deploy  [required]
   --retain-resources TEXT  Logical Ids of resources to retain
   --help                   Show this message and exit.
+```
+
+### get-output
+
+Sometimes it's necessary to get an output value from a stack to pass to something else.
+While SSM parameter store or CloudFormation exports are a preferred way to pass values between stacks, this can be used
+to pass a value from one stackmanager execution to another (e.g. when they are in different regions):
+
+```
+myoutput=$(stackmanger get-output -e dev -r us-east-1 -c mystack.yml -o OutputKey)
+```
+
+The output value will be the only value written to stdout.
+
+If the stack does not exist, or a matching output does not exist an error will be printed to stderr and the return
+code will be -1.
+
+```
+Usage: stackmanager get-output [OPTIONS]
+
+  Returns matching Output value if it exists.
+
+Options:
+  -p, --profile TEXT      AWS Profile, will use default or environment variables if not specified
+  -c, --config-file TEXT  YAML Configuration file  [required]
+  -e, --environment TEXT  Environment to deploy  [required]
+  -r, --region TEXT       AWS Region to deploy
+  -o, --output-key TEXT   Output Key  [required]
+  --help                  Show this message and exit.
 ```
 
 ### status

--- a/stackmanager/messages.py
+++ b/stackmanager/messages.py
@@ -1,4 +1,16 @@
 import click
+import tabulate
+
+
+TABLE_FORMAT = 'simple'
+
+
+def echo(message):
+    """
+    Print message without coloring
+    :param str message: Message
+    """
+    click.echo(message)
 
 
 def info(message):
@@ -22,4 +34,8 @@ def error(message):
     Print error level message in bold red
     :param str message: Message
     """
-    click.secho(message, fg='red', bold=True)
+    click.secho(message, fg='red', bold=True, err=True)
+
+
+def table(data, headers):
+    click.echo(tabulate.tabulate(data, headers=headers, tablefmt=TABLE_FORMAT))

--- a/stackmanager/runner.py
+++ b/stackmanager/runner.py
@@ -5,9 +5,8 @@ import uuid
 from botocore.exceptions import ClientError, WaiterError
 from stackmanager.config import Config
 from stackmanager.exceptions import StackError, ValidationError
-from stackmanager.messages import info, warn, error
+from stackmanager.messages import echo, info, warn, error, table
 from stackmanager.status import StackStatus
-from tabulate import tabulate
 from textwrap import wrap
 
 
@@ -28,45 +27,6 @@ class Runner:
         self.change_set_name = change_set_name if change_set_name else 'c'+str(uuid.uuid4()).replace('-', '')
         self.stack = self.load_stack()
 
-    def load_stack(self):
-        """
-        Load Description of stack to determine if it exists and the current status
-        :return: Matching stack of None
-        """
-        try:
-            stacks = self.client.describe_stacks(StackName=self.config.stack_name)['Stacks']
-            stack = stacks[0]
-            stack_timestamp = stack['LastUpdatedTime'] if 'LastUpdatedTime' in stack else stack['CreationTime']
-            info(f'\nStack: {self.config.stack_name}, Status: {StackStatus.get_status(stack).name} '
-                 f'({self.format_timestamp(stack_timestamp)})')
-            return stack
-        except ClientError as ce:
-            if ce.response['Error']['Code'] == 'ValidationError':
-                info(f'\nStack: {self.config.stack_name}, Status: does not exist')
-                return None
-            else:
-                raise StackError(ce)
-
-    def check_change_sets(self):
-        """
-        Check for existing change sets, and depending upon 'ExistingChanges' setting we may prevent the deployment
-        :raises ValidationError: If ChangeSets exist and are not allowed
-        """
-        if self.stack:
-            change_sets = self.client.list_change_sets(StackName=self.config.stack_name)['Summaries']
-            change_sets.sort(key=lambda c: c['CreationTime'])
-            successful_change_sets = [c for c in change_sets if c['Status'] in ['CREATE_PENDING', 'CREATE_IN_PROGRESS',
-                                                                                'CREATE_COMPLETE']]
-
-            if change_sets:
-                print('\nExisting ChangeSets:')
-                for cs in change_sets:
-                    print(f'  {self.format_timestamp(cs["CreationTime"])}: {cs["ChangeSetName"]} ({cs["Status"]})')
-                if self.config.existing_changes == 'DISALLOW':
-                    raise ValidationError('Creation of new ChangeSet not allowed when existing ChangeSets found')
-                elif self.config.existing_changes == 'FAILED_ONLY' and successful_change_sets:
-                    raise ValidationError('Creation of new ChangeSet not allowed when existing valid ChangeSets found')
-
     def deploy(self):
         """
         Create a new Stack or update an existing Stack using a ChangeSet.
@@ -76,6 +36,8 @@ class Runner:
         :raises StackError: If creating the ChangeSet or executing it fails
         :raises ValidationError: If stack is not in a deployable status
         """
+        self.print_stack_status()
+
         if not StackStatus.is_creatable(self.stack) and not StackStatus.is_updatable(self.stack):
             stack_status = StackStatus.get_status(self.stack)
             if stack_status == StackStatus.ROLLBACK_COMPLETE:
@@ -97,6 +59,150 @@ class Runner:
                     self.pending_change_set(change_set_id)
         except ClientError as ce:
             raise StackError(ce)
+
+    def apply_change_set(self):
+        """
+        Apply Change Set, first printing the current stack status.
+        """
+        self.print_stack_status()
+        self.execute_change_set()
+
+    def reject_change_set(self):
+        """
+        Delete the named ChangeSet, and if the stack is in the REVIEW_IN_PROGRESS status and there are
+        no remaining ChangeSets, then delete the stack.
+        """
+        if not self.stack:
+            raise ValidationError(f'Stack {self.config.stack_name} not found')
+
+        self.print_stack_status()
+        try:
+            self.client.describe_change_set(ChangeSetName=self.change_set_name, StackName=self.config.stack_name)
+        except self.client.exceptions.ChangeSetNotFoundException:
+            raise ValidationError(f'ChangeSet {self.change_set_name} not found')
+
+        info(f'\nDeleting ChangeSet {self.change_set_name} for {self.config.stack_name}')
+
+        self.client.delete_change_set(ChangeSetName=self.change_set_name, StackName=self.config.stack_name)
+
+        if StackStatus.is_status(self.stack, StackStatus.REVIEW_IN_PROGRESS):
+            change_sets = self.client.list_change_sets(StackName=self.config.stack_name)['Summaries']
+            if not change_sets:
+                info(f'\nDeleting REVIEW_IN_PROGRESS Stack {self.config.stack_name} that has no remaining ChangeSets')
+                # Delete stack, no need to wait for deletion to complete
+                self.client.delete_stack(StackName=self.config.stack_name)
+
+    def delete(self, retain_resources=[]):
+        """
+        Delete a Stack, optionally retraining certain resources.
+        Waits for Stack to delete and prints Events if deletion fails
+        :param list retain_resources: List of LogicalIds to retain
+        :raises StackError: if deletion fails
+        """
+        if not self.stack:
+            raise ValidationError(f'Stack {self.config.stack_name} not found')
+
+        self.print_stack_status()
+
+        if not StackStatus.is_deletable(self.stack):
+            raise ValidationError(f'Stack {self.config.stack_name} is not in a deletable status: '
+                                  f'{StackStatus.get_status(self.stack).name}')
+
+        info(f'\nDeleting Stack {self.config.stack_name}')
+        last_timestamp = self.get_last_timestamp()
+
+        try:
+            self.client.delete_stack(StackName=self.config.stack_name, RetainResources=retain_resources)
+
+            self.client.get_waiter('stack_delete_complete').wait(
+                StackName=self.config.stack_name,
+                WaiterConfig={'Delay': 10, 'MaxAttempts': 360})
+
+            info(f'\nDeletion of Stack {self.config.stack_name} successfully completed')
+            self.stack = None
+        except ClientError as ce:
+            raise StackError(ce)
+        except WaiterError as we:
+            error(f'\nDeletion of Stack {self.config.stack_name} failed:\n')
+            self.print_events(last_timestamp)
+            raise StackError(we)
+
+    def status(self, event_days):
+        """
+        Output the current status of the stack showing pending ChangeSets and recent events.
+        :param int event_days: Number of days to show events for
+        """
+        self.print_stack_status()
+        self.check_change_sets()
+
+        if self.stack:
+            last_timestamp = arrow.utcnow().shift(days=-event_days)
+            info(f'\nEvents since {self.format_timestamp(last_timestamp)}:\n')
+            self.print_events(last_timestamp.datetime)
+            self.print_outputs()
+
+    def get_output(self, output_key):
+        """
+        Return value of matching output, or throw exception
+        :param str output_key: Output Key to return value for
+        :return: Matching output value
+        :raises ValidationError: If stack does not exist or matching output not found
+        """
+        if not self.stack:
+            raise ValidationError(f'Stack {self.config.stack_name} not found')
+
+        output_value = next((o['OutputValue'] for o in self.stack.get('Outputs', []) if o['OutputKey'] == output_key),
+                            None)
+        if output_value:
+            return output_value
+        raise ValidationError(f'Output {output_key} not found')
+
+    def load_stack(self):
+        """
+        Load Description of stack to determine if it exists and the current status
+        :return: Matching stack of None
+        """
+        try:
+            stacks = self.client.describe_stacks(StackName=self.config.stack_name)['Stacks']
+            stack = stacks[0]
+            return stack
+        except ClientError as ce:
+            if ce.response['Error']['Code'] == 'ValidationError':
+                return None
+            else:
+                raise StackError(ce)
+
+    def print_stack_status(self):
+        """
+        Print the status of the stack if it exists or does not, with last update (or creation) timestamp.
+        """
+        if self.stack:
+            stack_timestamp = self.stack['LastUpdatedTime'] if 'LastUpdatedTime' in self.stack \
+                else self.stack['CreationTime']
+            info(f'\nStack: {self.config.stack_name}, Status: {StackStatus.get_status(self.stack).name} '
+                 f'({self.format_timestamp(stack_timestamp)})')
+        else:
+            info(f'\nStack: {self.config.stack_name}, Status: does not exist')
+
+    def check_change_sets(self):
+        """
+        Check for existing change sets, and depending upon 'ExistingChanges' setting we may prevent the deployment
+        :raises ValidationError: If ChangeSets exist and are not allowed
+        """
+        if self.stack:
+            change_sets = self.client.list_change_sets(StackName=self.config.stack_name)['Summaries']
+            change_sets.sort(key=lambda c: c['CreationTime'])
+            successful_change_sets = [c for c in change_sets if c['Status'] in ['CREATE_PENDING', 'CREATE_IN_PROGRESS',
+                                                                                'CREATE_COMPLETE']]
+
+            if change_sets:
+                echo('\nExisting ChangeSets:')
+                for cs in change_sets:
+                    echo(f'  {self.format_timestamp(cs["CreationTime"])}: {cs["ChangeSetName"]} ({cs["Status"]})')
+                if self.config.existing_changes == 'DISALLOW':
+                    raise ValidationError('Creation of new ChangeSet not allowed when existing ChangeSets found')
+                elif self.config.existing_changes == 'FAILED_ONLY' and successful_change_sets:
+                    raise ValidationError('Creation of new ChangeSet not allowed when existing valid ChangeSets found')
 
     def pending_change_set(self, change_set_id):
         """Subclasses can override this to export the change set information in another format"""
@@ -133,12 +239,12 @@ class Runner:
         describe_change_set_response = self.client.describe_change_set(ChangeSetName=self.change_set_name,
                                                                        StackName=self.config.stack_name)
 
-        table = [[change['ResourceChange']['Action'],
-                  change['ResourceChange']['LogicalResourceId'],
-                  change['ResourceChange']['ResourceType'],
-                  change['ResourceChange'].get('Replacement', '-')]
-                 for change in describe_change_set_response['Changes']]
-        print(tabulate(table, headers=['Action', 'LogicalResourceId', 'ResourceType', 'Replacement']))
+        data = [[change['ResourceChange']['Action'],
+                 change['ResourceChange']['LogicalResourceId'],
+                 change['ResourceChange']['ResourceType'],
+                 change['ResourceChange'].get('Replacement', '-')]
+                for change in describe_change_set_response['Changes']]
+        table(data, ['Action', 'LogicalResourceId', 'ResourceType', 'Replacement'])
         return True
 
     def execute_change_set(self):
@@ -161,6 +267,9 @@ class Runner:
             info(f'\nChangeSet {self.change_set_name} for {self.config.stack_name} successfully completed:\n')
             self.print_events(last_timestamp)
 
+            self.stack = self.load_stack()
+            self.print_outputs()
+
         except ClientError as ce:
             raise StackError(ce)
         except WaiterError as we:
@@ -174,74 +283,6 @@ class Runner:
         """
         error(f'\nChangeSet {self.change_set_name} for {self.config.stack_name} failed:\n')
         self.print_events(last_timestamp)
-
-    def reject_change_set(self):
-        """
-        Delete the named ChangeSet, and if the stack is in the REVIEW_IN_PROGRESS status and there are
-        no remaining ChangeSets, then delete the stack.
-        """
-        if not self.stack:
-            raise ValidationError(f'Stack {self.config.stack_name} not found')
-
-        try:
-            self.client.describe_change_set(ChangeSetName=self.change_set_name, StackName=self.config.stack_name)
-        except self.client.exceptions.ChangeSetNotFoundException:
-            raise ValidationError(f'ChangeSet {self.change_set_name} not found')
-
-        info(f'\nDeleting ChangeSet {self.change_set_name} for {self.config.stack_name}')
-
-        self.client.delete_change_set(ChangeSetName=self.change_set_name, StackName=self.config.stack_name)
-
-        if StackStatus.is_status(self.stack, StackStatus.REVIEW_IN_PROGRESS):
-            change_sets = self.client.list_change_sets(StackName=self.config.stack_name)['Summaries']
-            if not change_sets:
-                info(f'\nDeleting REVIEW_IN_PROGRESS Stack {self.config.stack_name} that has no remaining ChangeSets')
-                # Delete stack, no need to wait for deletion to complete
-                self.client.delete_stack(StackName=self.config.stack_name)
-
-    def delete(self, retain_resources=[]):
-        """
-        Delete a Stack, optionally retraining certain resources.
-        Waits for Stack to delete and prints Events if deletion fails
-        :param list retain_resources: List of LogicalIds to retain
-        :raises StackError: if deletion fails
-        """
-        if not self.stack:
-            raise ValidationError(f'Stack {self.config.stack_name} not found')
-        if not StackStatus.is_deletable(self.stack):
-            raise ValidationError(f'Stack {self.config.stack_name} is not in a deletable status: '
-                                  f'{StackStatus.get_status(self.stack).name}')
-
-        info(f'\nDeleting Stack {self.config.stack_name}')
-        last_timestamp = self.get_last_timestamp()
-
-        try:
-            self.client.delete_stack(StackName=self.config.stack_name, RetainResources=retain_resources)
-
-            self.client.get_waiter('stack_delete_complete').wait(
-                StackName=self.config.stack_name,
-                WaiterConfig={'Delay': 10, 'MaxAttempts': 360})
-
-            info(f'\nDeletion of Stack {self.config.stack_name} successfully completed')
-            self.stack = None
-        except ClientError as ce:
-            raise StackError(ce)
-        except WaiterError as we:
-            error(f'\nDeletion of Stack {self.config.stack_name} failed:\n')
-            self.print_events(last_timestamp)
-            raise StackError(we)
-
-    def status(self, event_days):
-        """
-        Output the current status of the stack showing pending ChangeSets and recent events.
-        :param int event_days: Number of days to show events for
-        """
-        self.check_change_sets()
-
-        if self.stack:
-            last_timestamp = arrow.utcnow().shift(days=-event_days)
-            info(f'\nEvents since {self.format_timestamp(last_timestamp)}:\n')
-            self.print_events(last_timestamp.datetime)
 
     def get_last_timestamp(self):
         """
@@ -259,20 +300,25 @@ class Runner:
         """
         paginator = self.client.get_paginator('describe_stack_events')
         iterator = paginator.paginate(StackName=self.config.stack_name)
-        table = []
+        data = []
         for page in iterator:
             for event in page['StackEvents']:
                 if not last_timestamp or event['Timestamp'] > last_timestamp:
                     reason = '\n'.join(wrap(event.get('ResourceStatusReason', '-'), 50))
-                    table.append([self.format_timestamp(event['Timestamp']), event['LogicalResourceId'],
-                                  event['ResourceType'], event['ResourceStatus'], reason])
+                    data.append([self.format_timestamp(event['Timestamp']), event['LogicalResourceId'],
+                                event['ResourceType'], event['ResourceStatus'], reason])
 
-        if table:
-            table.reverse()
-            print(tabulate(table, headers=['Timestamp', 'LogicalResourceId', 'ResourceType', 'ResourceStatus',
-                                           'Reason']))
+        if data:
+            data.reverse()
+            table(data, ['Timestamp', 'LogicalResourceId', 'ResourceType', 'ResourceStatus', 'Reason'])
         else:
             warn('No events')
+
+    def print_outputs(self):
+        if self.stack and 'Outputs' in self.stack:
+            info('\nOutputs:\n')
+            data = [[o['OutputKey'], o['OutputValue']] for o in self.stack['Outputs']]
+            table(data, ['Key', 'Value'])
 
     def build_change_set_args(self):
         """


### PR DESCRIPTION
Prints outputs in a table after executing change sets and in the status output.
Adds get-output command to retrieve a single output value without printing anything else. This required moving the printing of the stack status information from the constructor to the individual methods on the runner.